### PR TITLE
Refine email regex in git-summary script

### DIFF
--- a/scripts/git/git-summary.sh
+++ b/scripts/git/git-summary.sh
@@ -38,7 +38,7 @@ _git_summary() {
 
   git log "${log_args[@]}" --pretty=format:"%an <%ae>" |
     sort | uniq | while read -r author; do
-      email=$(echo "$author" | grep -oE "<.*>" | tr -d "<>")
+      email=$(echo "$author" | grep -oE '<[^>]+>' | tr -d '<>')
       name=$(echo "$author" | sed -E "s/ <.*>//")
       short_email=$(printf "%.40s" "$email")
 


### PR DESCRIPTION
## Summary
- use non-greedy regex in `git-summary` to properly capture author email addresses

## Testing
- `bash -n scripts/git/git-summary.sh`
- `apt-get update` *(fails: The repository 'http://apt.llvm.org/noble llvm-toolchain-noble-20 InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_6897eb6c394c832d91977184673d028b